### PR TITLE
Fixed page scroll bar staying from where link clicked

### DIFF
--- a/src/components/Helper/ScrollToTop.ts
+++ b/src/components/Helper/ScrollToTop.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { RouteComponentProps, withRouter } from "react-router";
+
+// Scroll restoration based on https://reacttraining.com/react-router/web/guides/scroll-restoration.
+export const ScrollToTop = withRouter(
+  class ScrollToTopWithoutRouter extends React.Component<RouteComponentProps<any>, void> {
+    componentDidUpdate(prevProps: Readonly<RouteComponentProps<any>>) {
+      if (this.props.location !== prevProps.location) {
+        window.scrollTo(0, 0)
+      }
+    }
+
+    render(): JSX.Element {
+      return null;
+    }
+  }
+);

--- a/src/routes.js
+++ b/src/routes.js
@@ -18,6 +18,7 @@ import NewRequest from './components/forms/NewRequest.jsx';
 import Footer from './components/Footer/Footer.jsx';
 import NotFound from './components/Error/404.jsx';
 import Dashboard from './Dashboard.jsx';
+import { ScrollToTop } from './components/Helper/ScrollToTop.ts';
 
 import ReduxThunk from 'redux-thunk';
 import { createStore, applyMiddleware, compose } from 'redux';
@@ -52,6 +53,8 @@ export const makeMainRoutes = () => {
     <Router history={history}>
       <Provider store={store}>
         <div>
+
+          <ScrollToTop />
 
           <Header auth={auth} props={store} />
 


### PR DESCRIPTION
When you click a post link, the scroll bar doesn't go back to top. 

I updated links to reset the scroll bar to the top of the page on click. 